### PR TITLE
Fix typo in spreadsheet header

### DIFF
--- a/src/SimGolfShotsExcelWriter.php
+++ b/src/SimGolfShotsExcelWriter.php
@@ -44,7 +44,7 @@ class SimGolfShotsExcelWriter {
         $sheet->setCellValue([$i++, $j], 'Smash Factor');   
         $sheet->setCellValue([$i++, $j], 'Apex Height');   
         $sheet->setCellValue([$i++, $j], 'Total Deviation Distance'); 
-        $sheet->setCellValue([$i++, $j], 'Spin Callculation Type');   
+        $sheet->setCellValue([$i++, $j], 'Spin Calculation Type');
         $sheet->setCellValue([$i++, $j], 'Ball Type');   
         $sheet->setCellValue([$i++, $j], 'Temperature');   
         $sheet->setCellValue([$i++, $j], 'Humidity');   


### PR DESCRIPTION
## Summary
- fix typo for spin calculation column header

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad52ba53c83329b32ea19ac6c1c1d