### PR TITLE
Fix uninitialized shots and clean GolfShot

### DIFF
--- a/src/GolfShot.php
+++ b/src/GolfShot.php
@@ -128,10 +128,6 @@ class GolfShot {
             $this->ballType = $club?->ballType;
         }
 
-        if(isset($club->ballType)) {
-            $this->ballType = $club?->ballType;
-        }
-
         if(isset($club->temperature)) {
             $this->temperature = (float)$club?->temperature;
         }

--- a/src/GolfSimSession.php
+++ b/src/GolfSimSession.php
@@ -5,7 +5,7 @@ class GolfSimSession implements GolfData {
 
     private GolfSessionSummary $summary;
 
-    private array $shots;
+    private array $shots = [];
 
     public function __construct(\stdClass $data) {
         $this->summary = new GolfSessionSummary($data->summary);

--- a/tests/GolfSimSessionTest.php
+++ b/tests/GolfSimSessionTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+require_once realpath("vendor/autoload.php");
+
+use PHPUnit\Framework\TestCase;
+use R10Analyzer\GolfSimSession;
+
+final class GolfSimSessionTest extends TestCase
+{
+    public function testEmptyShotsAreInitialized(): void
+    {
+        $summaryData = (object) [
+            'clientKey' => 'dummy',
+            'name' => 'session',
+            'startTime' => '2023-01-01T00:00:00.000Z',
+            'endTime' => '2023-01-01T00:00:00.000Z',
+            'numShots' => 0,
+            'type' => 'DRIVING_RANGE',
+            'drivingRangeId' => 1
+        ];
+
+        $sessionData = (object) [
+            'summary' => $summaryData,
+            'shots' => []
+        ];
+
+        $session = new GolfSimSession($sessionData);
+        $this->assertIsArray($session->getShots());
+        $this->assertCount(0, $session->getShots());
+    }
+}


### PR DESCRIPTION
## Summary
- initialize shot list in GolfSimSession so `getShots()` works even when the session contains no shots
- remove duplicate `ballType` assignment in GolfShot
- add regression test for GolfSimSession empty shots

## Testing
- `vendor/bin/phpunit --colors=always tests` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*
- `vendor/bin/phpstan analyse src tests` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686ad17ff3ec83329fcc6737fad12662